### PR TITLE
drop refstack base job and relocate golang-make job

### DIFF
--- a/zuul.d/go-jobs.yaml
+++ b/zuul.d/go-jobs.yaml
@@ -1,5 +1,13 @@
 ---
 - job:
+    name: golang-make
+    parent: golang-go
+    description: |
+      Run golang commands under make
+    pre-run: playbooks/golang/make-pre.yaml
+    run: playbooks/golang/make-run.yaml
+
+- job:
     name: otc-golang-make
     parent: golang-make
     nodeset: fedora-pod

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,25 +1,5 @@
 ---
 - job:
-    name: refstack-client-run-base
-    parent: unittests
-    attempts: 1
-    required-projects:
-      - opendev.org/osf/refstack-client
-    pre-run: playbooks/refstack-client/pre.yaml
-    run: playbooks/refstack-client/run.yaml
-    post-run: playbooks/refstack-client/post.yaml
-    nodeset:
-      nodes:
-        - name: refstack
-          label: debian-buster
-    timeout: 10800
-    vars:
-      tempest_tests_url: https://refstack.openstack.org/api/v1/guidelines/2019.11/tests?target=platform&type=required&alias=true&flag=false
-      refstack_tempest_tag: tags/23.0.0
-      zuul_work_dir: "{{ ansible_user_dir }}/{{ zuul.projects['opendev.org/osf/refstack-client'].src_dir }}"
-      refstack_environment: "dummy"
-
-- job:
     name: refstack-client-run
     parent: refstack-client-run-base
     vars:
@@ -49,11 +29,3 @@
       - secret: refstack_database
         name: refstack_database
         pass-to-parent: true
-
-- job:
-    name: golang-make
-    parent: golang-go
-    description: |
-      Run golang commands under make
-    pre-run: playbooks/golang/make-pre.yaml
-    run: playbooks/golang/make-run.yaml


### PR DESCRIPTION
- drop refstack-base job (moved to project-config)
- moved golang-make job under go-jobs