### PR TITLE
Try using ubuntu-focal for the ansible linters job

### DIFF
--- a/zuul.d/ansible-collection-jobs.yaml
+++ b/zuul.d/ansible-collection-jobs.yaml
@@ -86,6 +86,7 @@
       Run openstack collections linter tests using the devel branch of ansible
     # non-voting because we can't prevent ansible devel from breaking us
     voting: false
+    nodeset: ubuntu-focal
     required-projects:
       - name: ansible/ansible
         override-checkout: devel
@@ -96,6 +97,7 @@
     description: |
       Run openstack collections linter tests using the 2.10 branch of ansible
     voting: true
+    nodeset: ubuntu-focal
     required-projects:
       - name: ansible/ansible
         override-checkout: stable-2.10
@@ -106,6 +108,7 @@
     description: |
       Run openstack collections linter tests using the 2.9 branch of ansible
     voting: true
+    nodeset: ubuntu-focal
     required-projects:
       - name: ansible/ansible
         override-checkout: stable-2.9

--- a/zuul.d/python-jobs.yaml
+++ b/zuul.d/python-jobs.yaml
@@ -3,7 +3,7 @@
     name: otc-tox
     parent: tox
     abstract: true
-    nodeset: fedora-pod
+    nodeset: ubuntu-focal
     description: |
       Base job for running tox jobs
 


### PR DESCRIPTION
linters jobs tend to hang trying to upload data into the pod. While other similar jobs work, those do not. For the moment switch them to use real VMs