### PR TITLE
Define latest golang version

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -11,6 +11,7 @@ skip_list:
            # ansible-lint are fixed.
   - '208'  # File permissions not mentioned
   - '301'  # Commands should not change things if nothing needs doing
+  - '302'  # Using command rather than an argument to e.g. file
 rulesdir:
   - ./.rules/
 use_default_rules: true

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,6 @@
 exclude_paths:
   - test-playbooks/  # TODO(ssbarnea): remove skip in follow-up
+  - zuul.d/secrets.yaml
 parseable: true
 quiet: false
 skip_list:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module test-playbooks/goreleaser/project
+
+go 1.15

--- a/playbooks/ansible-test-base/run.yaml
+++ b/playbooks/ansible-test-base/run.yaml
@@ -8,10 +8,9 @@
         ansible_test_collection_namespace: "{{ ansible_test_collections|ternary(ansible_collection_namespace, '') }}"
 
     - name: Run ansible-test
-      import_role:
+      include_role:
         name: ansible-test
       vars:
         ansible_test_venv_path: "{{ ensure_ansible_root_dir }}"
         ansible_test_ansible_path: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
         ansible_test_python: "{{ python_version }}"
-

--- a/playbooks/golang/goreleaser-pre.yaml
+++ b/playbooks/golang/goreleaser-pre.yaml
@@ -1,5 +1,7 @@
 ---
 - hosts: all
   roles:
-    - ensure-go
+    - role: ensure-go
+      vars:
+        go_version: "1.16.3"
     - ensure-goreleaser

--- a/playbooks/golang/make-pre.yaml
+++ b/playbooks/golang/make-pre.yaml
@@ -1,4 +1,6 @@
 ---
 - hosts: all
   roles:
-    - ensure-go
+    - role: ensure-go
+      vars:
+        go_version: "1.16.3"

--- a/playbooks/golang/make-pre.yaml
+++ b/playbooks/golang/make-pre.yaml
@@ -1,6 +1,4 @@
 ---
 - hosts: all
   roles:
-    - role: ensure-go
-      vars:
-        go_version: "1.16.3"
+    - ensure-go

--- a/test-playbooks/goreleaser/project/.goreleaser.yml
+++ b/test-playbooks/goreleaser/project/.goreleaser.yml
@@ -1,18 +1,23 @@
-project_name: fake
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod tidy
 builds:
   - env:
+      - CGO_ENABLED=0
     flags:
       - -trimpath
     goos:
       - linux
     goarch:
       - amd64
-    binary: '{{ .ProjectName }}'
+    binary: "{{ .ProjectName }}"
 archives:
   - format: tar.gz
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 signs:
   - artifacts: checksum

--- a/test-playbooks/goreleaser/project/main.go
+++ b/test-playbooks/goreleaser/project/main.go
@@ -3,5 +3,5 @@ package main
 import "fmt"
 
 func main() {
-  fmt.Println("hello world")
+	fmt.Println("hello world")
 }

--- a/zuul.d/go-jobs.yaml
+++ b/zuul.d/go-jobs.yaml
@@ -2,6 +2,8 @@
 - job:
     name: golang-make
     parent: golang-go
+    vars:
+      go_version: "1.16.3"
     description: |
       Run golang commands under make
     pre-run: playbooks/golang/make-pre.yaml


### PR DESCRIPTION
go1.16+ is required for building `darmin arm64` binary

Tested in https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/974