### PR TITLE
Increase timeout for docs job

### DIFF
--- a/zuul.d/python-jobs.yaml
+++ b/zuul.d/python-jobs.yaml
@@ -92,3 +92,6 @@
     run: playbooks/tox-docs/run.yaml
     post-run: playbooks/tox-docs/post.yaml
     success-url: docs/
+    # OTC Docs may take 30 min only to push 26000
+    # files into VM
+    timeout: 3600


### PR DESCRIPTION
OTC docs is so huge, that the job times out. Increase timeout
