### PR TITLE
Add publish-otc-releasenotes job into rn template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -81,6 +81,12 @@
         - build-otc-releasenotes:
             vars:
               sphinx_python: python3
+    tag:
+      jobs:
+        - publish-otc-releasenotes
+    release:
+      jobs:
+        - publish-otc-releasenotes
     promote:
       jobs:
         - promote-otc-releasenotes


### PR DESCRIPTION
tag jobs can not fetch RN, cause gate didn't run. Trigger a special job in this case.