### PR TITLE
Drop alerts file

### DIFF
--- a/roles/publish-alerts/tasks/main.yaml
+++ b/roles/publish-alerts/tasks/main.yaml
@@ -37,3 +37,8 @@
         loop_var: zj_alert_item
       no_log: true
       failed_when: false
+
+    - name: Delete alerts file
+      file:
+        path: "{{ p.stat.path }}"
+        state: "absent"


### PR DESCRIPTION
After we have emited alerts drop the file not to save it in the log
directory
