### PR TITLE
Reduce number of threads for uploading logs

### DIFF
--- a/roles/upload-logs-base1/library/zuul_swift_upload.py
+++ b/roles/upload-logs-base1/library/zuul_swift_upload.py
@@ -60,7 +60,7 @@ except ImportError:
         retry_function,
     )
 
-MAX_UPLOAD_THREADS = 24
+MAX_UPLOAD_THREADS = 12
 
 
 def get_cloud(cloud):


### PR DESCRIPTION
some jobs are failing with "unauthorized" while trying to upload logs.
The only idea at the moment is to try reducing amnount of parallel
threads.
