### PR TITLE
Try uploading logs as archive

### DIFF
--- a/roles/upload-logs-swift1/tasks/main.yaml
+++ b/roles/upload-logs-swift1/tasks/main.yaml
@@ -28,6 +28,7 @@
         files:
           - "{{ zuul.executor.log_root }}/"
         delete_after: "{{ zuul_log_delete_after | default(omit) }}"
+        archive_mode: true
       register: upload_results
 
 - name: Setting zuul_upload_logs_results


### PR DESCRIPTION
We face API throttling and as a mean to workaround this it is possible
to upload logs as singe archive asking it to unpack this on server.
