### PR TITLE
swift

### DIFF
--- a/roles/upload-logs-base1/library/zuul_swift_upload.py
+++ b/roles/upload-logs-base1/library/zuul_swift_upload.py
@@ -169,7 +169,7 @@ class Uploader():
                 except Exception:
                     pass
             tar.close()
-            failures.append(self.post_archive("data.tar.gz"))
+            failures.append(self.post_archive(fp.name))
             os.remove(fp.name)
             return failures
 


### PR DESCRIPTION
- do not use tempfile context
- use tempfile name
