### PR TITLE
Revert "Switch ansible tox-linter to fedora-pod nodeset"

### DIFF
--- a/zuul.d/ansible-collection-jobs.yaml
+++ b/zuul.d/ansible-collection-jobs.yaml
@@ -118,7 +118,7 @@
     description: |
       Run openstack collections linter tests using the 2.9 branch of ansible
     voting: true
-    nodeset: fedora-pod
+    nodeset: ubuntu-focal
     required-projects:
       - name: ansible/ansible
         override-checkout: stable-2.9


### PR DESCRIPTION
Reverts opentelekomcloud-infra/otc-zuul-jobs#77

We also checkout ansible and copying whole ansible tree into the pod takes ages