### PR TITLE
Switch to regular tox-linters job in ansible collection template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -23,7 +23,7 @@
         - otc-tox-pep8
         # - tox-functional
         # - tox-linters-ansible-devel
-        - tox-linters-ansible-2.10
+        - tox-linters
         - ansible-collection-build
         - ansible-collection-test-sanity
         - ansible-collection-test-units
@@ -33,7 +33,7 @@
       jobs:
         - otc-tox-pep8
         # - tox-linters-ansible-devel
-        - tox-linters-ansible-2.10
+        - tox-linters
         - ansible-collection-build
         - ansible-collection-test-sanity
         - ansible-collection-test-units


### PR DESCRIPTION
Pushing whole ansible into the pod is taking too long. We can instead
stop even trying that and rely completely only on the ansible-linters
being done as tox-linter job in the project.
