### PR TITLE
Add create-vault-approle-token role

### DIFF
--- a/roles/create-vault-approle-token/README.rst
+++ b/roles/create-vault-approle-token/README.rst
@@ -1,0 +1,27 @@
+Create File with vault approle login token
+
+**Role Variables**
+
+.. zuul:rolevar:: vault_addr
+
+   Vault URL.
+
+.. zuul:rolevar:: vault_client_token
+
+   Client token to use for unwrapping secret_id,
+
+.. zuul:rolevar:: vault_wrapping_token_id
+
+   Wrapped secret-id.
+
+.. zuul:rolevar:: vault_role_id
+
+   Role-Id of the AppRole.
+
+.. zuul:rolevar:: vault_secret_id
+
+   Optional secret_id. Either it or wrapped secret_id must be passed.
+
+.. zuul:rolevar:: vault_token_dest
+
+   Destination where to write client token to.

--- a/roles/create-vault-approle-token/tasks/main.yaml
+++ b/roles/create-vault-approle-token/tasks/main.yaml
@@ -1,0 +1,59 @@
+- name: Lookup unwrap secret - verify it has expected data
+  no_log: true
+  uri:
+    url: "{{ vault_addr }}/v1/sys/wrapping/lookup"
+    headers:
+      X-Vault-Token: "{{ vault_token }}"
+    body:
+      token: "{{ vault_wrapping_token_id }}"
+    body_format: json
+    method: "POST"
+  when:
+    - "vault_token is defined"
+    - "vault_wrapping_token_id is defined"
+    - "vault_role_name is defined"
+  failed_when:
+    - "vault_unwrap_lookup_data.json.data.creation_path != 'auth/approle/role/' + vault_role_name + '/secret-id'"
+  register: vault_unwrap_lookup_data
+
+- name: Unwrap secret
+  no_log: true
+  uri:
+    url: "{{ vault_addr }}/v1/sys/wrapping/unwrap"
+    headers:
+      X-Vault-Token: "{{ vault_token }}"
+    body:
+      token: "{{ vault_wrapping_token_id }}"
+    body_format: json
+    method: "POST"
+  when:
+    - "vault_token is defined"
+    - "vault_wrapping_token_id is defined"
+  register: vault_unwrap_data
+
+- name: Login to vault
+  no_log: true
+  uri:
+    url: "{{ vault_addr }}/v1/auth/approle/login"
+    body:
+      role_id: "{{ vault_role_id }}"
+      secret_id: "{{ vault_secret_id | default(vault_unwrap_data.json.data.secret_id) }}"
+    body_format: json
+    method: "POST"
+  when:
+  register: vault_token_data
+
+# NOTE(gtema): even the module does not leak content we do not want even
+# checksum of it to be easily readable, therefore use no_log
+- name: Write vault token into the destination
+  no_log: true
+  copy:
+    content: "{{ vault_token_data.json.auth.client_token }}"
+    dest: "{{ vault_token_dest }}"
+    mode: "0400"
+  when:
+    - "vault_token_dest is defined"
+    - "vault_token_data is defined"
+    - "vault_token_data.json is defined"
+    - "vault_token_data.json.auth is defined"
+    - "vault_token_data.json.auth.client_token is defined"

--- a/test-playbooks/create-vault-approle-token.yaml
+++ b/test-playbooks/create-vault-approle-token.yaml
@@ -1,0 +1,59 @@
+- hosts: all
+  environment:
+    VAULT_ADDR: "http://127.0.0.1:8200"
+    VAULT_TOKEN: "root"
+  vars:
+    secret_dest: "{{ ansible_user_dir }}/.vault_wrap_secret"
+    token_dest: "{{ ansible_user_dir }}/.vault_test_token"
+    vault_addr: "http://127.0.0.1:8200"
+    vault_token: "root"
+    vault_role_name: "test"
+  roles:
+    - ensure-vault
+  tasks:
+    - name: Start vault in dev mode
+      command: "/usr/local/bin/vault server -dev -dev-root-token-id=root"
+      async: 300
+      poll: 0
+
+    - name: Enable approle auth
+      command: "/usr/local/bin/vault auth enable approle"
+
+    - name: Create test approle
+      command: "/usr/local/bin/vault write -f auth/approle/role/{{ vault_role_name }}"
+
+    - name: Get approle role-id
+      uri:
+        url: "{{ vault_addr }}/v1/auth/approle/role/{{ vault_role_name }}/role-id"
+        headers:
+          X-Vault-Token: "{{ vault_token }}"
+        method: "GET"
+      register: vault_approle_role_id
+
+    - name: Generate new secret for the role
+      include_role:
+        name: "create-vault-approle-secret"
+      vars:
+        vault_secret_dest: "{{ secret_dest }}"
+
+    - name: Get content of the created secret
+      slurp:
+        src: "{{ secret_dest }}"
+      register: secret
+
+    - name: Generate AppRole token
+      include_role:
+        name: "create-vault-approle-token"
+      vars:
+        vault_role_id: "{{ vault_approle_role_id.json.data.role_id }}"
+        vault_wrapping_token_id: "{{ secret['content'] | b64decode }}"
+        vault_token_dest: "{{ token_dest }}"
+
+    - name: Get content of the created token
+      slurp:
+        src: "{{ token_dest }}"
+      register: token
+
+    - name: Debug created token
+      debug:
+        msg: "{{ token['content'] | b64decode }}"

--- a/zuul-tests.d/vault-roles-jobs.yaml
+++ b/zuul-tests.d/vault-roles-jobs.yaml
@@ -13,10 +13,20 @@
       - roles/create-vault-approle-secret
     run: test-playbooks/create-vault-approle-secret.yaml
 
+- job:
+    name: zuul-jobs-test-create-vault-approle-token
+    description: Test create-vault-approle-token job
+    files:
+      - roles/ensure-vault
+      - roles/create-vault-approle-secret
+      - roles/create-vault-approle-token
+    run: test-playbooks/create-vault-approle-token.yaml
+
 - project:
     merge-mode: squash-merge
     check: &id001
       jobs:
         - zuul-jobs-test-ensure-vault
         - zuul-jobs-test-create-vault-approle-secret
+        - zuul-jobs-test-create-vault-approle-token
     gate: *id001


### PR DESCRIPTION
Add a role which uses vault approle role-id and secret-id (can be
wrapped) to login to vault and write token into file
