### PR TITLE
Use wrapped token itself for unwrap

### DIFF
--- a/roles/create-vault-approle-token/tasks/main.yaml
+++ b/roles/create-vault-approle-token/tasks/main.yaml
@@ -21,13 +21,11 @@
   uri:
     url: "{{ vault_addr }}/v1/sys/wrapping/unwrap"
     headers:
-      X-Vault-Token: "{{ vault_token }}"
+      X-Vault-Token: "{{ vault_wrapping_token_id }}"
     body:
-      token: "{{ vault_wrapping_token_id }}"
     body_format: json
     method: "POST"
   when:
-    - "vault_token is defined"
     - "vault_wrapping_token_id is defined"
   register: vault_unwrap_data
 


### PR DESCRIPTION
Vault supports using wrapped token for authenticating, but in this case
body should be empty. Since we might want to use the role in untrusted
context switch to this approach.
