### PR TITLE
Set container attributes properly

### DIFF
--- a/roles/upload-artifact-swift/library/upload_artifact_swift.py
+++ b/roles/upload-artifact-swift/library/upload_artifact_swift.py
@@ -64,7 +64,11 @@ def main():
         else:
             read_acl = p['read_acl']
         cloud.update_container(
-            p['container'], {'x-container-read': read_acl})
+            p['container'], {
+                'x-container-read': read_acl,
+                'X-Container-Meta-Web-Index': 'index.html',
+                'X-Container-Meta-Access-Control-Allow-Origin': '*'
+            })
 
         with open(p['src'], 'rb') as f:
             headers = {


### PR DESCRIPTION
When uploading artifacts we should ensure created container has required
properties so that static hosting works.
