### PR TITLE
Move json output generation to the main doc job

### DIFF
--- a/playbooks/tox-docs/post.yaml
+++ b/playbooks/tox-docs/post.yaml
@@ -2,3 +2,4 @@
   roles:
     - fetch-tox-output
     - fetch-sphinx-tarball
+    - fetch-sphinx-json

--- a/playbooks/tox-docs/pre.yaml
+++ b/playbooks/tox-docs/pre.yaml
@@ -1,7 +1,11 @@
 - hosts: all
   roles:
-    - bindep
+    - role: bindep
+      bindep_profile: doc
     - ensure-tox
     - ensure-python
     - role: prepare-build-pdf-docs
       when: not tox_skip_pdf
+    - role: ensure-sphinx
+      doc_building_packages:
+        - sphinx

--- a/playbooks/tox-docs/run.yaml
+++ b/playbooks/tox-docs/run.yaml
@@ -4,3 +4,6 @@
     - tox
     - role: build-pdf-docs
       when: not tox_skip_pdf
+    # Build json output
+    - role: sphinx
+      sphinx_builders: json

--- a/roles/fetch-sphinx-json/tasks/main.yaml
+++ b/roles/fetch-sphinx-json/tasks/main.yaml
@@ -29,14 +29,14 @@
 
 - name: Create browseable Json directory
   file:
-    path: "{{ zuul_output_dir }}/logs/docs"
+    path: "{{ zuul_output_dir }}/logs/docs-json"
     state: directory
     mode: 0755
 
-- name: Extract archive HTML
+- name: Extract archive JSON
   unarchive:
     src: "{{ zuul_output_dir }}/logs/docs-json.tar.gz"
-    dest: "{{ zuul_output_dir }}/logs/docs"
+    dest: "{{ zuul_output_dir }}/logs/docs-json"
     remote_src: true
     extra_opts:
       - "--no-same-owner"
@@ -49,8 +49,8 @@
           - name: "Docs archive"
             url: "docs-json.tar.gz"
             metadata:
-              type: docs_archive
+              type: docs_archive_json
           - name: "Docs json preview"
-            url: "docs/"
+            url: "docs-json/"
             metadata:
-              type: docs_site
+              type: docs_site_json


### PR DESCRIPTION
Running dedicated job for producing json output is not efficient. We can
actually reuese instance where we produce docs to also generate json as
additional step.
