### PR TITLE
switch various doc jobs to use focal vm

### DIFF
--- a/roles/prepare-build-pdf-docs/vars/Debian.yaml
+++ b/roles/prepare-build-pdf-docs/vars/Debian.yaml
@@ -1,0 +1,17 @@
+packages:
+  - imagemagick
+  - latexmk
+  - fonts-lmodern
+  - fonts-liberation
+  - texlive-latex-base
+  - texlive-latex-extra
+  - texlive-xetex
+  - texlive-fonts-recommended
+  - fonts-freefont-otf
+  # Required for tgtermes.sty style, this is a recommended package
+  # for texlive-fonts-recommended but it is not installed by default.
+  - tex-gyre
+  - cm-super
+  - xindy
+  # Required by sphinxcontrib-svg2pdfconverter to handle SVG images
+  - librsvg2-bin

--- a/roles/prepare-build-pdf-docs/vars/RedHat.yaml
+++ b/roles/prepare-build-pdf-docs/vars/RedHat.yaml
@@ -1,5 +1,5 @@
 packages:
-  - gif2png
+  - ImageMagick
   - latexmk
   - liberation-mono-fonts
   - liberation-sans-fonts

--- a/zuul.d/doc-jobs.yaml
+++ b/zuul.d/doc-jobs.yaml
@@ -5,6 +5,7 @@
     description: |
       Build api-ref document. This is only run on master branch of a project.
     timeout: 1800
+    nodeset: ubuntu-focal
     vars:
       tox_envlist: api-ref
       tox_pdf_envlist: api-ref-pdf-docs
@@ -26,6 +27,7 @@
     description: |
       Build UMN document. This is only run on master branch of a project.
     timeout: 1800
+    nodeset: ubuntu-focal
     vars:
       tox_envlist: umn
       tox_pdf_envlist: umn-pdf-docs
@@ -47,6 +49,7 @@
     description: |
       Build Developer Guide document. This is only run on master branch of a project.
     timeout: 1800
+    nodeset: ubuntu-focal
     vars:
       tox_envlist: dg
       tox_pdf_envlist: dg-pdf-docs


### PR DESCRIPTION
Due to the performance problems of the K8 pods (while putting repo sources into the pod) we need to switch back to bare VMs which require only 3s instead of 10m for the same operation