### PR TITLE
Drop shebangs from modules

### DIFF
--- a/playbooks/library/installation_token.py
+++ b/playbooks/library/installation_token.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 from datetime import datetime
 import requests
 import base64

--- a/playbooks/library/vault_cloud_config.py
+++ b/playbooks/library/vault_cloud_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 import json
 
 from ansible.module_utils.basic import AnsibleModule

--- a/playbooks/library/vault_read.py
+++ b/playbooks/library/vault_read.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 import json
 
 from ansible.module_utils.basic import AnsibleModule

--- a/roles/publish-refstack-results/library/refstack_results.py
+++ b/roles/publish-refstack-results/library/refstack_results.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at

--- a/roles/revoke_token/library/os_auth_revoke.py
+++ b/roles/revoke_token/library/os_auth_revoke.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2014 Rackspace Australia
 # Copyright 2018 Red Hat, Inc
 #

--- a/roles/upload-logs-base1/library/delete_swift_container.py
+++ b/roles/upload-logs-base1/library/delete_swift_container.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2019 Red Hat, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/roles/upload-logs-base1/library/zuul_google_storage_upload.py
+++ b/roles/upload-logs-base1/library/zuul_google_storage_upload.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2014 Rackspace Australia
 # Copyright 2018-2019 Red Hat, Inc
 #

--- a/roles/upload-logs-base1/library/zuul_s3_upload.py
+++ b/roles/upload-logs-base1/library/zuul_s3_upload.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2014 Rackspace Australia
 # Copyright 2018 Red Hat, Inc
 #

--- a/roles/upload-logs-base1/library/zuul_swift_upload.py
+++ b/roles/upload-logs-base1/library/zuul_swift_upload.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2014 Rackspace Australia
 # Copyright 2018 Red Hat, Inc
 #

--- a/roles/upload-logs-base1/module_utils/zuul_jobs/upload_utils.py
+++ b/roles/upload-logs-base1/module_utils/zuul_jobs/upload_utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2014 Rackspace Australia
 # Copyright 2018-2019 Red Hat, Inc
 #

--- a/roles/upload-logs-otc-swift/library/zuul_swift_upload.py
+++ b/roles/upload-logs-otc-swift/library/zuul_swift_upload.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright 2014 Rackspace Australia
 # Copyright 2018 Red Hat, Inc
 #


### PR DESCRIPTION
https://github.com/ansible/ansible/commit/9142be2f6cabbe6597c9254c5bb9186d17036d55
gives us a little fun with the python interpreter being used. Drop
explicit shebangs from the modules.
