### PR TITLE
rollback to using python 3.9

### DIFF
--- a/zuul.d/ansible-collection-jobs.yaml
+++ b/zuul.d/ansible-collection-jobs.yaml
@@ -36,7 +36,7 @@
     pre-run: playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     vars:
-      python_version: "3.10"
+      python_version: "3.9"
       ansible_test_collections: true
 
 - job:


### PR DESCRIPTION
On debian bullseye there is no python3.10 package. Since we needed to fallback to debian due to pip broken on ubuntu drop down here