### PR TITLE
Add container jobs

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -10,6 +10,26 @@ mock_modules:
   - opentelekomcloud.gitcontrol.github_org_members
   - opentelekomcloud.gitcontrol.github_org_teams
   - opentelekomcloud.gitcontrol.github_org_repository
+mock_roles:
+  - bindep
+  - build-container-image
+  - ensure-docker
+  - ensure-if-python
+  - ensure-go
+  - ensure-pip
+  - ensure-podman
+  - ensure-python
+  - ensure-sphinx
+  - ensure-terraform
+  - ensure-tox
+  - fetch-sphinx-output
+  - fetch-sphinx-tarball
+  - fetch-tox-output
+  - promote-docker-image
+  - revoke-sudo
+  - sphinx
+  - tox
+  - upload-container-image
 loop_var_prefix: zj_
 enable_list:
   - no-same-owner
@@ -20,5 +40,19 @@ skip_list:
   - role-name  # Role name does not match ``^[a-z][a-z0-9_]+$`` pattern
   - command-instead-of-module  # Using command rather than module
   - git-latest  # Git checkouts must contain explicit version
+  # TODO: fix those
+  - fqcn-builtins
+  - deprecated-module
+  - key-order[task]
+  - jinja[spacing]
+  - schema[tasks]
+  - name[missing]
+  - name[template]
+  - name[casing]
+  - risky-file-permissions
+  - fqcn[action]
+  - args[module]
+  - name[play]
+  - ignore-errors
 use_default_rules: true
 verbosity: 1

--- a/doc/source/container-jobs.rst
+++ b/doc/source/container-jobs.rst
@@ -6,3 +6,5 @@ Jobs
 
 .. zuul:autojob:: simpleton
 .. zuul:autojob:: otc-build-docker-image
+.. zuul:autojob:: otc-build-container-image 
+.. zuul:autojob:: otc-upload-container-image 

--- a/linters-requirements.txt
+++ b/linters-requirements.txt
@@ -1,6 +1,6 @@
 # linters have different requirements than test ones, some would
 # conflict, like ansible version required by ansible-lint.
-ansible>=2.9,<2.11  # required by ansible-lint
+ansible>=2.12.0  # required by ansible-lint
 flake8
 yamllint>=1.23.0
-ansible-lint>=5.0.0,<6.0.0
+ansible-lint>6.8.0

--- a/playbooks/container-image/README.rst
+++ b/playbooks/container-image/README.rst
@@ -1,0 +1,69 @@
+This is one of a collection of jobs which are designed to work
+together to build, upload, and promote docker images in a gating
+context:
+
+  * :zuul:job:`otc-build-container-image`: Build the images.
+  * :zuul:job:`otc-upload-container-image`: Build and stage the images on dockerhub.
+
+The :zuul:job:`otc-build-container-image` job is designed to be used in
+a `check` pipeline and simply builds the images to verify that
+the build functions.
+
+The :zuul:job:`otc-upload-container-image` job builds and uploads the images
+to Docker Hub, but only with a single tag corresponding to the
+change ID.  This job is designed in a `gate` pipeline so that the
+build produced by the gate is staged and can later be promoted to
+production if the change is successful.
+
+They all accept the same input data, principally a list of
+dictionaries representing the images to build.  YAML anchors_ can be
+used to supply the same data to all three jobs.
+
+**Job Variables**
+
+.. zuul:jobvar:: zuul_work_dir
+   :default: {{ zuul.project.src_dir }}
+
+   The project directory.  Serves as the base for
+   :zuul:jobvar:`otc-build-container-image.container_images.context`.
+
+.. zuul:jobvar:: container_images
+   :type: list
+
+   A list of images to build.  Each item in the list should have:
+
+   .. zuul:jobvar:: context
+
+      The docker build context; this should be a directory underneath
+      :zuul:jobvar:`otc-build-container-image.zuul_work_dir`.
+
+   .. zuul:jobvar:: repository
+
+      The name of the target repository in dockerhub for the
+      image.  Supply this even if the image is not going to be
+      uploaded (it will be tagged with this in the local
+      registry).
+
+   .. zuul:jobvar:: path
+
+      Optional: the directory that should be passed to docker build.
+      Useful for building images with a Dockerfile in the context
+      directory but a source repository elsewhere.
+
+   .. zuul:jobvar:: build_args
+      :type: list
+
+      Optional: a list of values to pass to the docker ``--build-arg``
+      parameter.
+
+   .. zuul:jobvar:: target
+
+      Optional: the target for a multi-stage build.
+
+   .. zuul:jobvar:: tags
+      :type: list
+      :default: ['latest']
+
+      A list of tags to be added to the image when promoted.
+
+.. _anchors: https://yaml.org/spec/1.2/spec.html#&%20anchor//

--- a/playbooks/container-image/credentials.rst
+++ b/playbooks/container-image/credentials.rst
@@ -1,0 +1,22 @@
+.. zuul:jobvar:: container_registry_credentials
+   :type: dict
+
+   This is expected to be a Zuul Secret with these keys:
+
+   .. zuul:jobvar:: username
+
+      The Dockerer registry username.
+
+   .. zuul:jobvar:: password
+
+      The Docker registry password.
+
+   .. zuul:jobvar:: repository
+
+      Optional; if supplied this is a regular expression which
+      restricts to what repositories the image may be uploaded.  The
+      following example allows projects to upload images to
+      repositories within an organization based on their own names::
+
+        repository: "^myorgname/{{ zuul.project.short_name }}.*"
+

--- a/playbooks/container-image/pre.yaml
+++ b/playbooks/container-image/pre.yaml
@@ -1,0 +1,11 @@
+- hosts: all
+  tasks:
+    - name: Update APT cache to let install podman  # noqa no-handler
+      become: true
+      ansible.builtin.apt:
+        update_cache: yes
+      failed_when: false
+
+- hosts: all
+  roles:
+    - ensure-podman

--- a/playbooks/container-image/promote.yaml
+++ b/playbooks/container-image/promote.yaml
@@ -1,0 +1,3 @@
+- hosts: localhost
+  roles:
+    - promote-docker-image

--- a/playbooks/container-image/run.yaml
+++ b/playbooks/container-image/run.yaml
@@ -1,0 +1,3 @@
+- hosts: all
+  roles:
+    - build-container-image

--- a/playbooks/container-image/upload.yaml
+++ b/playbooks/container-image/upload.yaml
@@ -1,0 +1,3 @@
+- hosts: all
+  roles:
+    - upload-container-image

--- a/playbooks/functest/pre.yaml
+++ b/playbooks/functest/pre.yaml
@@ -28,11 +28,13 @@
 
     - name: Save data for later revocation
       delegate_to: localhost
-      ansible.builtin.copy:
-        dest: "{{ zuul.executor.work_root }}/.{{ zuul.build }}.functest"
+      vars:
         content:
           cloud_creds:
             lease_id: "{{ vault_data.json.lease_id }}"
+      ansible.builtin.copy:
+        dest: "{{ zuul.executor.work_root }}/.{{ zuul.build }}.functest"
+        content: "{{ content | to_json }}"
         mode: "0440"
 
     - name: Include deploy-clouds-config role

--- a/playbooks/gitcontrol/run.yaml
+++ b/playbooks/gitcontrol/run.yaml
@@ -50,7 +50,7 @@
         - name: Dump extra_vars
           copy:
             dest: "{{ extra_vars_tmp.path }}"
-            content: "{{ extra_vars | to_nice_yaml }}"
+            content: "{{ extra_vars | to_nice_yaml }}"  # noqa jinja
             mode: "0600"
 
         - name: Log execution header

--- a/playbooks/refstack-client/post.yaml
+++ b/playbooks/refstack-client/post.yaml
@@ -1,8 +1,7 @@
 - hosts: all
   roles:
     - role: fetch-refstack-subunit-output
-      vars:
+
 - hosts: localhost
   roles:
     - role: publish-refstack-results
-      vars:

--- a/test-playbooks/container/docker/Dockerfile
+++ b/test-playbooks/container/docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch

--- a/zuul-tests.d/container-jobs.yaml
+++ b/zuul-tests.d/container-jobs.yaml
@@ -7,7 +7,7 @@
     files:
       - playbooks/simpleton/*
       - roles/simpleton/*
-      - zuul.d/dockerized-jobs.yaml
+      - zuul.d/container-jobs.yaml
     vars:
       simple_env:
         LI: "leeee"
@@ -17,10 +17,24 @@
       simple_run:
         - cat package.json
 
+- job:
+    name: zuul-jobs-test-build-container-image
+    parent: otc-build-container-image
+    files:
+      - playbooks/container-image/*
+      - zuul.d/container-jobs.yaml
+      - zuul-test.d/container-jobs.yaml
+    vars:
+      container_images:
+        - context: test-playbooks/container/docker
+          repository: fake/fake
+          tags: ['latest']
+
 - project:
     merge-mode: squash-merge
     check: &id001
       jobs:
         - zuul-jobs-test-simpleton:
             voting: false
+        - zuul-jobs-test-build-container-image
     gate: *id001

--- a/zuul.d/container-jobs.yaml
+++ b/zuul.d/container-jobs.yaml
@@ -26,3 +26,31 @@
     attempts: 1
     pre-run: playbooks/simpleton/pre.yaml
     run: playbooks/simpleton/run.yaml
+
+- job:
+    name: otc-build-docker-image
+    parent: build-docker-image
+    nodeset: ubuntu-jammy
+    timeout: 2700
+    description: |
+      Base job for running build of docker images
+
+- job:
+    name: otc-build-container-image
+    description: |
+      Build a container image.
+
+      .. include:: ../../playbooks/container-image/README.rst
+    nodeset: ubuntu-jammy
+    pre-run: playbooks/container-image/pre.yaml
+    run: playbooks/container-image/run.yaml
+
+- job:
+    name: otc-upload-container-image
+    parent: otc-build-container-image
+    description: |
+      Build and upload a container image.
+
+      .. include:: ../../playbooks/container-image/README.rst
+      .. include:: ../../playbooks/container-image/credentials.rst
+    post-run: playbooks/container-image/upload.yaml

--- a/zuul.d/python-jobs.yaml
+++ b/zuul.d/python-jobs.yaml
@@ -107,11 +107,3 @@
       Build releasenotes, with optional translation support, using reno.
     # Building translated releasenotes can take long for large repositories
     timeout: 3600
-
-- job:
-    name: otc-build-docker-image
-    parent: build-docker-image
-    nodeset: ubuntu-focal
-    timeout: 2700
-    description: |
-      Base job for running build of docker images


### PR DESCRIPTION
Opendev has XXX-container-image roles that can use podman. Copy/rename
docker jobs and make our own otc-XXX-container-jobs.
