### PR TITLE
Fork upload-container-image role

### DIFF
--- a/playbooks/container-image/pre.yaml
+++ b/playbooks/container-image/pre.yaml
@@ -1,11 +1,3 @@
 - hosts: all
-  tasks:
-    - name: Update APT cache to let install podman  # noqa no-handler
-      become: true
-      ansible.builtin.apt:
-        update_cache: yes
-      failed_when: false
-
-- hosts: all
   roles:
-    - ensure-podman
+    - ensure-podman1

--- a/playbooks/container-image/run.yaml
+++ b/playbooks/container-image/run.yaml
@@ -1,3 +1,3 @@
 - hosts: all
   roles:
-    - build-container-image
+    - build-container-image1

--- a/playbooks/container-image/upload.yaml
+++ b/playbooks/container-image/upload.yaml
@@ -1,3 +1,3 @@
 - hosts: all
   roles:
-    - upload-container-image
+    - upload-container-image1

--- a/roles/build-container-image1/README.rst
+++ b/roles/build-container-image1/README.rst
@@ -1,0 +1,3 @@
+Build one or more container images.
+
+.. include:: ../../roles/build-container-image/common.rst

--- a/roles/build-container-image1/common.rst
+++ b/roles/build-container-image1/common.rst
@@ -1,0 +1,147 @@
+This is one of a collection of roles which are designed to work
+together to build, upload, and promote container images in a gating
+context:
+
+* :zuul:role:`build-container-image`: Build the images.
+
+.. note:: Build and upload roles are forthcoming.
+
+The :zuul:role:`build-container-image` role is designed to be used in
+`check` and `gate` pipelines and simply builds the images.  It can be
+used to verify that the build functions, or it can be followed by the
+use of subsequent roles to upload the images to a registry.
+
+They all accept the same input data, principally a list of
+dictionaries representing the images to build.  YAML anchors_ can be
+used to supply the same data to all three jobs.
+
+Use the :zuul:role:`ensure-docker` or :zuul:role:`ensure-podman`
+role to install Docker or Podman before using these roles.
+
+**Role Variables**
+
+.. zuul:rolevar:: zuul_work_dir
+   :default: {{ zuul.project.src_dir }}
+
+   The project directory.  Serves as the base for
+   :zuul:rolevar:`build-container-image.container_images.context`.
+
+.. zuul:rolevar:: container_filename
+
+   The default container filename name to use. Serves as the base for
+   :zuul:rolevar:`build-container-image.container_images.container_filename`.
+   This allows a global overriding of the container filename name, for
+   example when building all images from different folders with
+   similarily named containerfiles.
+
+   If omitted, the default depends on the container command used.
+   Typically, this is ``Dockerfile`` for ``docker`` and
+   ``Containerfile`` (with a fallback on ``Dockerfile``) for
+   ``podman``.
+
+.. zuul:rolevar:: container_command
+   :default: podman
+
+   The command to use when building the image (E.g., ``docker``).
+
+.. zuul:rolevar:: container_registry_credentials
+   :type: dict
+
+   This is only required for the upload and promote roles.  This is
+   expected to be a Zuul Secret in dictionary form.  Each key is the
+   name of a registry, and its value a dictionary with information
+   about that registry.
+
+   Example:
+
+   .. code-block:: yaml
+
+      container_registry_credentials:
+        quay.io:
+          username: foo
+          password: bar
+
+   .. zuul:rolevar:: [registry name]
+      :type: dict
+
+      Information about a registry.  The key is the registry name, and
+      its value a dict as follows:
+
+      .. zuul:rolevar:: username
+
+         The registry username.
+
+      .. zuul:rolevar:: password
+
+         The registry password.
+
+      .. zuul:rolevar:: repository
+
+         Optional; if supplied this is a regular expression which
+         restricts to what repositories the image may be uploaded.  The
+         following example allows projects to upload images to
+         repositories within an organization based on their own names::
+
+           repository: "^myorgname/{{ zuul.project.short_name }}.*"
+
+.. zuul:rolevar:: container_images
+   :type: list
+
+   A list of images to build.  Each item in the list should have:
+
+   .. zuul:rolevar:: context
+
+      The build context; this should be a directory underneath
+      :zuul:rolevar:`build-container-image.zuul_work_dir`.
+
+   .. zuul:rolevar:: container_filename
+
+      The filename of the container file, present in the context
+      folder, used for building the image. Provide this if you are
+      using a non-standard filename for a specific image.
+
+   .. zuul:rolevar:: registry
+
+      The name of the target registry (E.g., ``quay.io``).  Used by
+      the upload and promote roles.
+
+   .. zuul:rolevar:: repository
+
+      The name of the target repository in the registry for the image.
+      Supply this even if the image is not going to be uploaded (it
+      will be tagged with this in the local registry).
+
+   .. zuul:rolevar:: path
+
+      Optional: the directory that should be passed to the build
+      command.  Useful for building images with a container file in
+      the context directory but a source repository elsewhere.
+
+   .. zuul:rolevar:: build_args
+      :type: list
+
+      Optional: a list of values to pass to the ``--build-arg``
+      parameter.
+
+   .. zuul:rolevar:: target
+
+      Optional: the target for a multi-stage build.
+
+   .. zuul:rolevar:: tags
+      :type: list
+      :default: ['latest']
+
+      A list of tags to be added to the image when promoted.
+
+   .. zuul:rolevar:: siblings
+      :type: list
+      :default: []
+
+      A list of sibling projects to be copied into
+      ``{{zuul_work_dir}}/.zuul-siblings``.  This can be useful to
+      collect multiple projects to be installed within the same Docker
+      context.  A ``-build-arg`` called ``ZUUL_SIBLINGS`` will be
+      added with each sibling project.  Note that projects here must
+      be listed in ``required-projects``.
+
+.. _anchors: https://yaml.org/spec/1.2/spec.html#&%20anchor//

--- a/roles/build-container-image1/defaults/main.yaml
+++ b/roles/build-container-image1/defaults/main.yaml
@@ -1,0 +1,2 @@
+zuul_work_dir: "{{ zuul.project.src_dir }}"
+container_command: podman

--- a/roles/build-container-image1/tasks/build.yaml
+++ b/roles/build-container-image1/tasks/build.yaml
@@ -1,0 +1,60 @@
+- name: Check sibling directory
+  stat:
+    path: '{{ zuul_work_dir }}/{{ zj_image.context }}/.zuul-siblings'
+  register: _dot_zuul_siblings
+
+# This should have been cleaned up; multiple builds may specify
+# different siblings to include so we need to start fresh.
+- name: Check for clean build
+  assert:
+    that: not _dot_zuul_siblings.stat.exists
+
+- name: Create sibling source directory
+  file:
+    path: '{{ zuul_work_dir }}/{{ zj_image.context }}/.zuul-siblings'
+    state: directory
+    mode: 0755
+  when: zj_image.siblings is defined
+
+- name: Copy sibling source directories
+  command:
+    cmd: 'cp --parents -r {{ zj_sibling }} {{ ansible_user_dir }}/{{ zuul_work_dir }}/{{ zj_image.context }}/.zuul-siblings'
+    chdir: '~/src'
+  loop: '{{ zj_image.siblings }}'
+  loop_control:
+    loop_var: zj_sibling
+  when: zj_image.siblings is defined
+
+- name: Set container filename arg
+  set_fact:
+    containerfile: "{{ zj_image.container_filename | default(container_filename) | default('') }}"
+
+- name: Build a container image
+  vars:
+    tag_prefix: "{{ ('change_' + zuul.change) if (zuul.change is defined) else zuul.pipeline }}_"
+    image_name: "{{ (zj_image.registry + '/' + zj.image.repository) if (zj_image.registry is defined) else zj_image.repository }}"
+  command: >-
+    {{ container_command }} build {{ zj_image.path | default('.') }} {% if containerfile %}-f {{ containerfile }}{% endif %}
+    {% if container_command == 'podman' -%}
+      --cgroup-manager cgroupfs
+    {% endif -%}
+    {% if zj_image.target | default(false) -%}
+      --target {{ zj_image.target }}
+    {% endif -%}
+    {% for build_arg in zj_image.build_args | default([]) -%}
+      --build-arg {{ build_arg }}
+    {% endfor -%}
+    {% if zj_image.siblings | default(false) -%}
+      --build-arg "ZUUL_SIBLINGS={{ zj_image.siblings | join(' ') }}"
+    {% endif -%}
+    {% for tag in zj_image.tags | default(['latest']) -%}
+      --tag {{ image_name }}:{{ tag_prefix }}{{ tag }}
+      --tag {{ image_name }}:{{ tag }}
+    {% endfor -%}
+  args:
+    chdir: "{{ zuul_work_dir }}/{{ zj_image.context }}"
+
+- name: Cleanup sibling source directory
+  file:
+    path: '{{ zuul_work_dir }}/{{ zj_image.context }}/.zuul-siblings'
+    state: absent

--- a/roles/build-container-image1/tasks/main.yaml
+++ b/roles/build-container-image1/tasks/main.yaml
@@ -1,0 +1,53 @@
+- name: Check for results.json
+  stat:
+    path: "{{ zuul.executor.result_data_file }}"
+  register: result_json_stat
+  delegate_to: localhost
+
+# This can be removed if we add this functionality to Zuul directly
+- name: Load information from zuul_return
+  set_fact:
+    buildset_registry: "{{ (lookup('file', zuul.executor.result_data_file) | from_json)['secret_data']['buildset_registry'] }}"
+  when:
+    - buildset_registry is not defined
+    - result_json_stat.stat.exists
+    - result_json_stat.stat.size > 0
+    - "'buildset_registry' in (lookup('file', zuul.executor.result_data_file) | from_json).get('secret_data')"
+  no_log: true
+
+- name: Build container images
+  include_tasks: build.yaml
+  loop: "{{ container_images }}"
+  loop_control:
+    loop_var: zj_image
+
+# Docker, and therefore skopeo and podman, don't understand docker
+# push [1234:5678::]:5000/image/path:tag so we set up /etc/hosts with
+# a registry alias name to support ipv6 and 4.
+- name: Configure /etc/hosts for buildset_registry to workaround not understanding ipv6 addresses
+  become: yes
+  lineinfile:
+    path: /etc/hosts
+    state: present
+    regex: "^{{ buildset_registry.host }}\tzuul-jobs.buildset-registry$"
+    line: "{{ buildset_registry.host }}\tzuul-jobs.buildset-registry"
+    insertafter: EOF
+  when: buildset_registry is defined and buildset_registry.host | ipaddr
+
+- name: Set buildset_registry alias variable when using ip
+  set_fact:
+    buildset_registry_alias: zuul-jobs.buildset-registry
+  when: buildset_registry is defined and buildset_registry.host | ipaddr
+
+- name: Set buildset_registry alias variable when using name
+  set_fact:
+    buildset_registry_alias: "{{ buildset_registry.host }}"
+  when: buildset_registry is defined and not ( buildset_registry.host | ipaddr )
+
+# Push each image.
+- name: Push image to buildset registry
+  when: buildset_registry is defined
+  include_tasks: push.yaml
+  loop: "{{ container_images }}"
+  loop_control:
+    loop_var: zj_image

--- a/roles/build-container-image1/tasks/push.yaml
+++ b/roles/build-container-image1/tasks/push.yaml
@@ -1,0 +1,19 @@
+- name: Tag image for buildset registry
+  command: >-
+    {{ container_command }} tag {{ zj_image.repository }}:{{ zj_image_tag }} {{ buildset_registry_alias }}:{{ buildset_registry.port }}/{{ zj_image.repository }}:{{ zj_image_tag }}
+  register: result
+  until: result is succeeded
+  retries: 3
+  loop: "{{ zj_image.tags | default(['latest']) }}"
+  loop_control:
+    loop_var: zj_image_tag
+
+- name: Push tag to buildset registry
+  command: >-
+    {{ container_command }} push {{ buildset_registry_alias }}:{{ buildset_registry.port }}/{{ zj_image.repository }}:{{ zj_image_tag }}
+  register: result
+  until: result is succeeded
+  retries: 3
+  loop: "{{ zj_image.tags | default(['latest']) }}"
+  loop_control:
+    loop_var: zj_image_tag

--- a/roles/ensure-podman1/README.rst
+++ b/roles/ensure-podman1/README.rst
@@ -1,0 +1,8 @@
+Install podman container manager
+
+**Role Variables**
+
+.. zuul:rolevar:: ensure_podman_validate
+   :default: false
+
+   Used to enable validation of podman engine.

--- a/roles/ensure-podman1/defaults/main.yaml
+++ b/roles/ensure-podman1/defaults/main.yaml
@@ -1,0 +1,1 @@
+ensure_podman_validate: false

--- a/roles/ensure-podman1/tasks/Debian.yaml
+++ b/roles/ensure-podman1/tasks/Debian.yaml
@@ -1,0 +1,9 @@
+- name: Install podman
+  package:
+    name:
+      - podman
+      - uidmap
+      - slirp4netns
+      - containernetworking-plugins
+    state: present
+  become: yes

--- a/roles/ensure-podman1/tasks/RedHat.yaml
+++ b/roles/ensure-podman1/tasks/RedHat.yaml
@@ -1,0 +1,4 @@
+- name: Install podman (RedHat)
+  become: true
+  package:
+    name: podman

--- a/roles/ensure-podman1/tasks/Ubuntu-18.04.yaml
+++ b/roles/ensure-podman1/tasks/Ubuntu-18.04.yaml
@@ -1,0 +1,23 @@
+- name: Add project atomic PPA repository
+  include_role:
+    name: ensure-package-repositories
+  vars:
+    repositories_list:
+      - repo: ppa:projectatomic/ppa
+
+- name: Install podman
+  package:
+    name:
+      - podman
+      - uidmap
+      - slirp4netns
+    state: present
+  become: yes
+
+# NOTE(pabelanger): Remove default registries.conf file, so we can manage it
+# ourself. It could have v1 syntax, which doesn't work with v2.
+- name: Remove /etc/containers/registries.conf
+  become: true
+  file:
+    state: absent
+    path: /etc/containers/registries.conf

--- a/roles/ensure-podman1/tasks/Ubuntu-20.04.yaml
+++ b/roles/ensure-podman1/tasks/Ubuntu-20.04.yaml
@@ -1,0 +1,3 @@
+- name: Not supported
+  fail:
+    msg: Ubuntu 20.04 not supported due to no known source of podman packages.

--- a/roles/ensure-podman1/tasks/Ubuntu-22.04.yaml
+++ b/roles/ensure-podman1/tasks/Ubuntu-22.04.yaml
@@ -1,0 +1,15 @@
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: yes
+  become: yes
+
+- name: Install podman
+  package:
+    name:
+      - podman
+      - uidmap
+      - slirp4netns
+      - fuse-overlayfs
+      - containernetworking-plugins
+    state: present
+  become: yes

--- a/roles/ensure-podman1/tasks/Ubuntu.yaml
+++ b/roles/ensure-podman1/tasks/Ubuntu.yaml
@@ -1,0 +1,27 @@
+- name: Add kubic project repository
+  include_role:
+    name: ensure-package-repositories
+  vars:
+    repositories_keys:
+      - url: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ ansible_distribution_version }}/Release.key"
+    repositories_list:
+      - repo: "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ ansible_distribution_version }}/ /"
+
+- name: Install podman
+  package:
+    name:
+      - podman
+      - uidmap
+      - slirp4netns
+      - fuse-overlayfs
+      - containernetworking-plugins
+    state: present
+  become: yes
+
+# NOTE(pabelanger): Remove default registries.conf file, so we can manage it
+# ourself. It could have v1 syntax, which doesn't work with v2.
+- name: Remove /etc/containers/registries.conf
+  become: true
+  file:
+    state: absent
+    path: /etc/containers/registries.conf

--- a/roles/ensure-podman1/tasks/default.yaml
+++ b/roles/ensure-podman1/tasks/default.yaml
@@ -1,0 +1,3 @@
+- name: Not implemented
+  fail:
+    msg: Role not implemented on this platform yet

--- a/roles/ensure-podman1/tasks/main.yaml
+++ b/roles/ensure-podman1/tasks/main.yaml
@@ -1,0 +1,28 @@
+- name: Find distribution installation
+  include_tasks: "{{ zj_distro_os }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yaml"
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yaml"
+    - "{{ ansible_distribution }}.yaml"
+    - "{{ ansible_os_family }}.yaml"
+    - "default.yaml"
+  loop_control:
+    loop_var: zj_distro_os
+
+- name: Fetch podman version
+  command: podman version
+  register: podman_ver
+
+- name: Print podman version installed
+  debug:
+    msg: "Podman version: {{ podman_ver.stdout }}"
+
+- name: Validate podman engine
+  when: ensure_podman_validate
+  # on purpose to verify that non-root user can call docker/podman
+  become: false
+  shell: |
+    podman version
+    podman info
+    podman ps
+  changed_when: false

--- a/roles/upload-container-image1/README.rst
+++ b/roles/upload-container-image1/README.rst
@@ -1,0 +1,13 @@
+Upload one or more container images.
+
+.. include:: ../../roles/build-container-image/common.rst
+
+.. zuul:rolevar:: upload_container_image_promote
+   :type: bool
+   :default: true
+
+   If ``true`` (the default), then this role will upload the image(s)
+   to the container registry with special tags designed for use by the
+   promote-container-image role.  Set to ``false`` to use
+   this role to directly upload images with the final tag (e.g., as
+   part of an un-gated release job).

--- a/roles/upload-container-image1/defaults/main.yaml
+++ b/roles/upload-container-image1/defaults/main.yaml
@@ -1,0 +1,3 @@
+zuul_work_dir: "{{ zuul.project.src_dir }}"
+upload_container_image_promote: true
+container_command: podman

--- a/roles/upload-container-image1/tasks/main.yaml
+++ b/roles/upload-container-image1/tasks/main.yaml
@@ -1,0 +1,15 @@
+- name: Verify repository names
+  when: |
+    container_registry_credentials is defined
+    and zj_image.registry not in container_registry_credentials
+  loop: "{{ container_images }}"
+  loop_control:
+    loop_var: zj_image
+  fail:
+    msg: "{{ zj_image.registry }} credentials not found"
+
+- name: Upload image to container registry
+  loop: "{{ container_images }}"
+  loop_control:
+    loop_var: zj_image
+  include_tasks: push.yaml

--- a/roles/upload-container-image1/tasks/push.yaml
+++ b/roles/upload-container-image1/tasks/push.yaml
@@ -1,0 +1,37 @@
+- name: Create tempfile for password
+  tempfile:
+    state: file
+  register: _password_tmp
+
+- name: Populate tempfile
+  copy:
+    content: "{{ container_registry_credentials[zj_image.registry].password }}"
+    dest: "{{ _password_tmp.path }}"
+    mode: 0600
+
+- name: Log in to registry
+  block:
+    - name: Log in to registry
+      shell: "cat {{ _password_tmp.path }} | {{ container_command }} login -u {{ container_registry_credentials[zj_image.registry].username }} --password-stdin {{ zj_image.registry }}"
+
+  always:
+    - name: Remove password from disk
+      command: "shred {{ _password_tmp.path }}"
+
+- name: Publish images
+  block:
+    - name: Upload tag to registry
+      vars:
+        promote_tag_prefix: "{{ ('change_' + zuul.change) if (zuul.change is defined) else zuul.pipeline }}_"
+      command: "{{ container_command }} push {{ zj_image.registry | ternary(zj_image.registry + '/', '' ) }}{ zj_image.repository }}:{{ upload_container_image_promote | ternary(promote_tag_prefix, '') }}{{ zj_image_tag }}"
+      loop: "{{ zj_image.tags | default(['latest']) }}"
+      loop_control:
+        loop_var: zj_image_tag
+      register: result
+      until: result.rc == 0
+      retries: 3
+      delay: 30
+
+  always:
+    - name: Log out of registry
+      command: "{{ container_command }} logout {{ zj_image.registry }}"


### PR DESCRIPTION
- copy upload-container-image role and apply 2 fixes:
  - set default container_command to podman
  - auto prepend image.registry during upload
- copy build-container-image role and prepend image.registry to the
  image name
- ensure apt cache updated before trying to install packages in
  ensure-podman
