### PR TITLE
add texlive-babel-english for PDF build

### DIFF
--- a/roles/prepare-build-pdf-docs/vars/RedHat.yaml
+++ b/roles/prepare-build-pdf-docs/vars/RedHat.yaml
@@ -4,6 +4,7 @@ packages:
   - liberation-mono-fonts
   - liberation-sans-fonts
   - liberation-serif-fonts
+  - texlive-babel-english
   - texlive-capt-of
   - texlive-cmap
   - texlive-fncychap


### PR DESCRIPTION
texlive-babel-english package appears to be now crucially needed for building PDF for the HelpCenter docs