### PR TITLE
Add six for project_cleanup

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,7 @@
 exclude_paths:
   - test-playbooks/  # TODO(ssbarnea): remove skip in follow-up
   - zuul.d/secrets.yaml
+  - roles/ansible-test/molecule/default
 parseable: true
 quiet: false
 mock_modules:
@@ -19,6 +20,7 @@ mock_roles:
   - ensure-pip
   - ensure-podman
   - ensure-python
+  - ensure-rust
   - ensure-sphinx
   - ensure-terraform
   - ensure-tox
@@ -55,5 +57,8 @@ skip_list:
   - name[play]
   - ignore-errors
   - risky-shell-pipe
+  - command-instead-of-shell
+  - no-free-form
+  - var-naming[no-role-prefix]
 use_default_rules: true
 verbosity: 1

--- a/playbooks/project_cleanup/pre.yaml
+++ b/playbooks/project_cleanup/pre.yaml
@@ -8,5 +8,6 @@
       ansible.builtin.pip:
         name:
           - openstacksdk
+          - six
         virtualenv: "{{ ansible_user_dir }}/.venv"
         virtualenv_command: "{{ ensure_pip_virtualenv_command }}"

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
   flake8 {posargs}
   yamllint -s -f parsable .
   ansible-lint --version
-  ansible-lint -v {env:ANSIBLELINT_OPTS:--progressive}
+  ansible-lint -v {env:ANSIBLELINT_OPTS:}
   # Ansible Syntax Check
   bash -c "find playbooks -type f -regex '.*.ya?ml' -print0 | xargs -t -n1 -0 ansible-lint"
   # {toxinidir}/tools/check_jobs_documented.py


### PR DESCRIPTION
https://opendev.org/openstack/keystoneauth/src/branch/master/keystoneauth1/identity/v3/oauth2_mtls_client_credential.py in latest released 5.2.0 pulls six which was dropped from requirements. Later it was fixed, but there is no release yet. In order to keep project cleanup running we need to install it ourselves (and once released - drop)