### PR TITLE
ansible 2.17 sanity update

### DIFF
--- a/zuul.d/ansible-collection-jobs.yaml
+++ b/zuul.d/ansible-collection-jobs.yaml
@@ -47,8 +47,8 @@
     vars:
       ansible_test_test_command: "sanity"
       ansible_test_skip_tests:
-        - metaclass-boilerplate
-        - future-import-boilerplate
+        # - metaclass-boilerplate
+        # - future-import-boilerplate
 
 - job:
     name: ansible-collection-test-units


### PR DESCRIPTION
Now metaclass-boilerplate and future-import-boilerplate not supported