### PR TITLE
goreleaser go version to 1.24.0

### DIFF
--- a/zuul.d/go-jobs.yaml
+++ b/zuul.d/go-jobs.yaml
@@ -42,7 +42,7 @@
     name: otc-golangci-lint
     parent: golangci-lint
     vars:
-      golangci_lint_version: 1.53.3
+      golangci_lint_version: 2.5.0
       go_version: 1.24.0
 
 - job:

--- a/zuul.d/go-jobs.yaml
+++ b/zuul.d/go-jobs.yaml
@@ -3,7 +3,7 @@
     name: golang-make
     parent: golang-go
     vars:
-      go_version: 1.20.4
+      go_version: 1.24.0
     description: |
       Run Golang commands under make
     pre-run: playbooks/golang/make-pre.yaml
@@ -35,7 +35,7 @@
     pre-run: playbooks/golang/goreleaser-pre.yaml
     run: playbooks/golang/goreleaser-build.yaml
     vars:
-      go_version: 1.20.4
+      go_version: 1.24.0
       goreleaser_args: "--snapshot --clean --skip=publish --skip=sign"
 
 - job:
@@ -43,7 +43,7 @@
     parent: golangci-lint
     vars:
       golangci_lint_version: 1.53.3
-      go_version: 1.20.4
+      go_version: 1.24.0
 
 - job:
     name: otc-terraform-visualize


### PR DESCRIPTION
I want to switch terraform provider to 1.24 version, there a lot of security changes and imporvements in compare with 1.20